### PR TITLE
Django 1.6 compatibility

### DIFF
--- a/registration_email/auth.py
+++ b/registration_email/auth.py
@@ -4,9 +4,18 @@ Custom authentication backends.
 Inspired by http://djangosnippets.org/snippets/2463/
 
 """
+import re
+
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import User
-from django.core.validators import email_re
+
+
+email_re = re.compile(
+    r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*"  # dot-atom
+    # quoted-string, see also http://tools.ietf.org/html/rfc2822#section-3.2.5
+    r'|^"([\001-\010\013\014\016-\037!#-\[\]-\177]|\\[\001-\011\013\014\016-\177])*"'
+    r')@((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)$)'  # domain
+    r'|\[(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\]$', re.IGNORECASE)  # literal form, ipv4 address (SMTP 4.1.3)
 
 
 class EmailBackend(ModelBackend):


### PR DESCRIPTION
Django 1.6 removed the email regex in django.core.validators that's used in registration_email.auth. This regex wasn't public API, so there wasn't any deprecation notice for it. As a quick fix I simply copied the regex over from Django 1.5, but it might be worth it to change email validation to use a proper validator so the regex doesn't have to be maintained by registration_email.
