### PR TITLE
fix at get_md5_digest, now it works with py3

### DIFF
--- a/registration_email/forms.py
+++ b/registration_email/forms.py
@@ -23,6 +23,8 @@ def get_md5_hexdigest(email):
     The length is 30 so that it fits into Django's ``User.username`` field.
 
     """
+    if isinstance(email, str):  # for py3
+        email = email.encode('utf-8')
     return hashlib.md5(email).hexdigest()[0:30]
 
 


### PR DESCRIPTION
'email' must be encoded before it can be hashed.
