### PR TITLE
Fixing URL pattern definition for django 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ custom form:
     from registration.backends.simple.views import RegistrationView
     from my_registration.forms import CustomEmailRegistrationForm
 
-    urlpatterns = patterns(
-        '' ,
+    urlpatterns = [
         ...
         url(
             r'^accounts/register/$',
@@ -131,7 +130,7 @@ custom form:
 
         url(r'^accounts/', include('registration_email.backends.default.urls')),
         ...
-    )
+    ]
 
 __3. Create a signal handler__
 

--- a/registration_email/auth_urls.py
+++ b/registration_email/auth_urls.py
@@ -5,15 +5,14 @@ This is done for convenience. It allows us to save all registration and auth
 related templates in the same `/templates/registration/` folder.
 
 """
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.contrib.auth import views as auth_views
 from registration_email.forms import EmailAuthenticationForm
 
 from .views import login_remember_me
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^login/$',
         login_remember_me,
@@ -64,4 +63,4 @@ urlpatterns = patterns(
         {'template_name': 'registration/password_reset_done.html'},
         name='password_reset_done',
     ),
-)
+]

--- a/registration_email/backends/default/urls.py
+++ b/registration_email/backends/default/urls.py
@@ -1,6 +1,6 @@
 """Custom urls.py for django-registration."""
 from django.conf import settings
-from django.conf.urls import include, url, patterns
+from django.conf.urls import include, url
 from django.views.generic import TemplateView
 
 from registration.backends.default.views import (
@@ -10,8 +10,7 @@ from registration.backends.default.views import (
 from registration_email.forms import EmailRegistrationForm
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     # django-registration views
     url(r'^activate/complete/$',
         TemplateView.as_view(
@@ -44,4 +43,4 @@ urlpatterns = patterns(
 
     # django auth urls
     url(r'', include('registration_email.auth_urls')),
-)
+]

--- a/registration_email/backends/simple/urls.py
+++ b/registration_email/backends/simple/urls.py
@@ -16,15 +16,14 @@ your own URL patterns for these views instead.
 
 """
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.views.generic.base import TemplateView
 
 from registration.backends.simple.views import RegistrationView
 from registration_email.forms import EmailRegistrationForm
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^register/$',
         RegistrationView.as_view(
             form_class=EmailRegistrationForm,
@@ -38,4 +37,4 @@ urlpatterns = patterns(
             template_name='registration/registration_closed.html'),
         name='registration_disallowed'),
     (r'', include('registration_email.auth_urls')),
-)
+]


### PR DESCRIPTION
Hi, we were using django-registration-email in an old project and noticed that it won't work with Django 1.11. At a quick glance, the problem seems to be the deprecated use of URLpatterns. This is a quick fix without much testing, have a look if you want to.
(In any case, this PR is a hint for anybody looking through the issues for a starting point).
Thanks!